### PR TITLE
Add missing AUR package required for SteamVR on Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ SteamVR is built on top of the Vulkan API and requires the latest Vulkan drivers
 
 **NVIDIA cards require version 375.27.10 of the NVIDIA Developer Beta Driver**. This can be downloaded from https://developer.nvidia.com/vulkan-driver. A Debian packaged version of this driver can be found in the "NVIDIA Development Drivers" PPA at https://launchpad.net/~mamarley/+archive/ubuntu/nvidia-dev/+packages. If you're also  using the graphics-drivers PPA, make sure the nvidia-dev PPA is pinned higher to use its driver over the nvidia-375 package in the graphics-drivers PPA. Thanks to Michael Marley for maintaining this PPA!
 
-An AUR package of the NVIDIA Developer Beta Driver is available for Arch Linux thanks to [gehneo on the SteamVR for Linux forum](http://steamcommunity.com/app/250820/discussions/5/133257959063392200/). Install it with the following:
+AUR packages providing the NVIDIA Developer Beta Driver are available for Arch Linux thanks to [gehneo on the SteamVR for Linux forum](http://steamcommunity.com/app/250820/discussions/5/133257959063392200/). Install with the following:
 
 ```
-yaourt -S nvidia-vulkan-developer-beta
+yaourt -S nvidia-vulkan-developer-beta lib32-nvidia-libgl-vulkan-developer-beta
 ```
 
 The NVIDIA driver supports direct mode, meaning the HMD will not appear on your desktop, or if it does, the display will have to be turned off in xrandr before being able to use VR.


### PR DESCRIPTION
Pulls in the extra package(s) required for SteamVR from the AUR. 

Thanks to @kkriehl for mentioning it. I wanted to get this out quickly so nobody would cone across the repo and break their install. 