### PR TITLE
Update Unreal Engine section with latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Version 1.0.7 of the OpenVR SDK has full support for Linux platforms: https://gi
 
 ## UNREAL ENGINE
 
-Unreal Engine 4.16 will have support for SteamVR on Linux. The 4.16 branch is currently available in the UE4 GitHub repository for preview access: https://github.com/EpicGames (requires free Epic Games account).
+Unreal Engine 4.16+ has support for SteamVR on Linux.
 
 ## UNITY DEVELOPMENT
 


### PR DESCRIPTION
Unreal Engine 4.16 released on May 24th, presumably users no longer need to pull from the preview branch.