### PR TITLE
update radv requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ sudo add-apt-repository ppa:mamarley/nvidia-dev
 
 The NVIDIA driver supports direct mode, meaning the HMD will not appear on your desktop, or if it does, the display will have to be turned off in xrandr before being able to use VR.
 
-**AMD graphics require a specific tree of the radv driver**. Use the **radv-wip-steamvr** branch of this repository: https://github.com/airlied/mesa. It doesn't support direct mode currently, so the HMD display will have to be positioned on your desktop in extended mode, and your system compositor disabled while using VR.
+**AMD graphics require the radv driver from Mesa 17.3 or above** or mainline mesa after [this commit](https://cgit.freedesktop.org/mesa/mesa/commit/?id=bfed189ee0ddfe9aad2c8732094434b7e1c5166d). For proper VK_KHR_external_semaphore_fd and EXT_memory_object_fd support Linux 4.13-rc1 or newer is required. It doesn't support direct mode currently, so the HMD display will have to be positioned on your desktop in extended mode, and your system compositor disabled while using VR.
  
 **Intel graphics are not currently supported**.
 


### PR DESCRIPTION
Shared Semaphores recently landed in linux 4.13-rc1 and radv git and with that SteamVR works on mesa master.

Patches for EXT_memory_object are on the mailing list https://lists.freedesktop.org/archives/mesa-dev/2017-July/162689.html or https://github.com/lostgoat/mesa/tree/wip-mem-obj-v4 and should land in the next few days so it's probably not worth mentioning it separately here for just that time.