### PR TITLE
Updated to latest Nvidia driver since

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For bugs, please file an issue on this github issue tracker. https://github.com/
 
 SteamVR is built on top of the Vulkan API and requires the latest Vulkan drivers. 
 
-**NVIDIA cards require version 384.69 of the NVIDIA Driver or above and to use the SteamVR Beta** An Ubuntu-packaged version of this driver can be found in the "Graphics Drivers" PPA at https://launchpad.net/~graphics-drivers/+archive/ubuntu/ppa.
+**NVIDIA cards require version 387.12 of the NVIDIA Driver or above and to use the SteamVR Beta** An Ubuntu-packaged version of this driver can be found in the "Graphics Drivers" PPA at https://launchpad.net/~graphics-drivers/+archive/ubuntu/ppa.
 
 ```
 sudo add-apt-repository ppa:graphics-drivers/ppa


### PR DESCRIPTION
...previous version(s) seem to longer work (error 306) after SteamVR updates (late October 2017).