### PR TITLE
Removed note on ppa update for Index audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,6 @@ kernel 4.13**.
 An Ubuntu-packaged version of this driver can be found in the "SteamVR Experimental Graphics" PPA
 at https://launchpad.net/~kisak/+archive/ubuntu/steamvr
 
-Note: The PPA has not been updated with Index Audio support. An update will land early next week
-once testing is completed.
-
 **If using this PPA, make sure a conflicting PPA like oibaf or padoka are not installed.**
 
 To setup "SteamVR Experimental Graphics" run:


### PR DESCRIPTION
Both of the reqired patches have been applied to the kernel in the PPA.
Audio now works with AMD cards while running that kernel.

See: https://launchpadlibrarian.net/431223500/linux_5.1.15-steamvr.steamvr1_source.changes